### PR TITLE
Add React frontend with Tailwind, themes, and i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+frontend/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-AI Codex Testing.
+# AI Codex Testing
+
+This repository includes a simple React frontend located in `frontend/` that demonstrates:
+
+- Multiple language support (English and Persian) with `react-i18next`
+- Automatic LTR/RTL switching based on the selected language
+- Component-based structure
+- Light and dark theme toggling with Tailwind CSS
+
+## Usage
+
+```
+cd frontend
+npm install
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Tailwind Multi-language</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-i18next": "^13.0.0",
+    "i18next": "^23.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "tailwindcss-rtl": "^0.9.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import LanguageSwitcher from './components/LanguageSwitcher';
+import ThemeSwitcher from './components/ThemeSwitcher';
+
+function App() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-white text-gray-800 dark:bg-gray-800 dark:text-gray-100">
+      <h1 className="text-3xl font-bold">{t('welcome')}</h1>
+      <p>{t('description')}</p>
+      <LanguageSwitcher />
+      <ThemeSwitcher />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/LanguageSwitcher.jsx
+++ b/frontend/src/components/LanguageSwitcher.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const LanguageSwitcher = () => {
+  const { i18n } = useTranslation();
+
+  const changeLanguage = (lng) => {
+    i18n.changeLanguage(lng);
+    document.documentElement.dir = lng === 'fa' ? 'rtl' : 'ltr';
+  };
+
+  return (
+    <div className="flex gap-2">
+      <button onClick={() => changeLanguage('en')} className="px-2 py-1 border rounded">
+        English
+      </button>
+      <button onClick={() => changeLanguage('fa')} className="px-2 py-1 border rounded">
+        فارسی
+      </button>
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/frontend/src/components/ThemeSwitcher.jsx
+++ b/frontend/src/components/ThemeSwitcher.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+const ThemeSwitcher = () => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+  }, [theme]);
+
+  return (
+    <div className="flex gap-2">
+      <button onClick={() => setTheme('light')} className="px-2 py-1 border rounded">
+        Light
+      </button>
+      <button onClick={() => setTheme('dark')} className="px-2 py-1 border rounded">
+        Dark
+      </button>
+    </div>
+  );
+};
+
+export default ThemeSwitcher;

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,28 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  en: {
+    translation: {
+      welcome: 'Welcome',
+      description: 'This is a sample application',
+    },
+  },
+  fa: {
+    translation: {
+      welcome: 'خوش آمدید',
+      description: 'این یک نمونه برنامه است',
+    },
+  },
+};
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources,
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+import './i18n';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+import rtl from 'tailwindcss-rtl';
+
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  darkMode: 'class',
+  plugins: [rtl()],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold React frontend with Tailwind CSS and Vite
- add language and theme switchers with RTL/LTR support
- document frontend usage in README

## Testing
- `npm test` (fails: `vitest: not found`)


------
https://chatgpt.com/codex/tasks/task_e_689a4cd63dc0832683fada6e9036fcfc